### PR TITLE
Chg: Allow use of any board-id

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,8 +107,8 @@ function build_platform()
   elif [[ ${aux_platforms[$platform_key]} ]]; then
     platform=${aux_platforms[$platform_key]}
   else
-    echo "INVALID PLATFORM KEY: $platform_key"
-    exit_code=1
+    echo "NON-STANDARD PLATFORM KEY: $platform_key"
+    platform=$platform_key
   fi
 
   echo -e "\n########################################################################";


### PR DESCRIPTION
A (new) board can be included with its full qualifier (e.g.: arduino:avr:uno).
`script:`
`  - build_platform arduino:avr:uno`
`  - build_platform leonardo`
`  - build_platform esp8266:esp8266:nodemcu`

 The build will fail, if the identifier is invalid, because the board will not loaded and exits with an error.