### PR TITLE
Upgrade to arduino 1.8.1 and add support for Circuit Playground.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,46 @@
+Thank you for opening an issue on an Adafruit Arduino library repository.  To
+improve the speed of resolution please review the following guidelines and
+common troubleshooting steps below before creating the issue:
+
+- **Do not use GitHub issues for troubleshooting projects and issues.**  Instead use
+  the forums at http://forums.adafruit.com to ask questions and troubleshoot why
+  something isn't working as expected.  In many cases the problem is a common issue
+  that you will more quickly receive help from the forum community.  GitHub issues
+  are meant for known defects in the code.  If you don't know if there is a defect
+  in the code then start with troubleshooting on the forum first.
+
+- **If following a tutorial or guide be sure you didn't miss a step.** Carefully
+  check all of the steps and commands to run have been followed.  Consult the
+  forum if you're unsure or have questions about steps in a guide/tutorial.
+
+- **For Arduino projects check these very common issues to ensure they don't apply**:
+
+  - For uploading sketches or communicating with the board make sure you're using
+    a **USB data cable** and **not** a **USB charge-only cable**.  It is sometimes
+    very hard to tell the difference between a data and charge cable!  Try using the
+    cable with other devices or swapping to another cable to confirm it is not
+    the problem.
+
+  - **Be sure you are supplying adequate power to the board.**  Check the specs of
+    your board and plug in an external power supply.  In many cases just
+    plugging a board into your computer is not enough to power it and other
+    peripherals.
+
+  - **Double check all soldering joints and connections.**  Flakey connections
+    cause many mysterious problems.  See the [guide to excellent soldering](https://learn.adafruit.com/adafruit-guide-excellent-soldering/tools) for examples of good solder joints.
+
+  - **Ensure you are using an official Arduino or Adafruit board.** We can't
+    guarantee a clone board will have the same functionality and work as expected
+    with this code and don't support them.
+
+If you're sure this issue is a defect in the code and checked the steps above
+please fill in the following fields to provide enough troubleshooting information.
+You may delete the guideline and text above to just leave the following details:
+
+- Arduino board:  **INSERT ARDUINO BOARD NAME/TYPE HERE**
+
+- Arduino IDE version (found in Arduino -> About Arduino menu):  **INSERT ARDUINO
+  VERSION HERE**
+
+- List the steps to reproduce the problem below (if possible attach a sketch or
+  copy the sketch code in too): **LIST REPRO STEPS BELOW**

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 script:
   - build_platform uno
   - build_platform leonardo
-  #- build_platform zero
+  - build_platform zero
   #- build_platform esp8266
   - build_platform circuitplay32u4cat
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - build_platform uno
   - build_platform leonardo
   - build_platform zero
-    #  - build_platform esp8266
+  - build_platform esp8266
   - build_platform circuitplay32u4cat
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - build_platform uno
   - build_platform leonardo
   - build_platform zero
-  #- build_platform esp8266
+  - build_platform esp8266
   - build_platform circuitplay32u4cat
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - build_platform uno
   - build_platform leonardo
   - build_platform zero
-  - build_platform esp8266
+    #  - build_platform esp8266
   - build_platform circuitplay32u4cat
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/install.sh)
+install:
+  - pip install esptool
 script:
   - build_platform uno
   - build_platform leonardo

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/install.sh)
 install:
-  - pip install esptool
+  - sudo pip install esptool
 script:
   - build_platform uno
   - build_platform leonardo

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - build_platform leonardo
   #- build_platform zero
   #- build_platform esp8266
-  - build_platform circuitplay32u4
+  - build_platform circuitplay32u4cat
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
   - build_platform leonardo
   #- build_platform zero
   #- build_platform esp8266
+  - build_platform circuitplay32u4
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
 script:
   - build_platform uno
   - build_platform leonardo
-  - build_platform zero
-  - build_platform esp8266
+  #- build_platform zero
+  #- build_platform esp8266
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c
-sudo: false
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/install.sh)
 script:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/
 **Example `.travis.yml`:**
 ```
 language: c
-sudo: false
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
 install:

--- a/arduino-headless.sh
+++ b/arduino-headless.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+killall -9 Xvfb
+Xvfb :1 -nolisten tcp -screen :1 1280x800x24 &
+xvfb="$!"
+sleep 1s
+DISPLAY=:1 arduino "$@"
+kill -9 $xvfb

--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,9 @@ sleep 3
 export DISPLAY=:1.0
 
 # download and install arduino 1.8.0
-wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
-tar xf arduino-1.8.0-linux64.tar.xz
-mv arduino-1.8.0 $HOME/arduino_ide
+wget https://downloads.arduino.cc/arduino-1.8.1-linux64.tar.xz
+tar xf arduino-1.8.1-linux64.tar.xz
+mv arduino-1.8.1 $HOME/arduino_ide
 wget https://raw.githubusercontent.com/fede2cr/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
 chmod +x $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder

--- a/install.sh
+++ b/install.sh
@@ -19,10 +19,10 @@ export AUX_PLATFORMS='declare -A aux_platforms=( [trinket]="adafruit:avr:trinket
 sleep 3
 export DISPLAY=:1.0
 
-# download and install arduino 1.8.0
-wget https://downloads.arduino.cc/arduino-1.8.1-linux64.tar.xz
-tar xf arduino-1.8.1-linux64.tar.xz
-mv arduino-1.8.1 $HOME/arduino_ide
+# download and install arduino 1.8.2
+wget https://downloads.arduino.cc/arduino-1.8.2-linux64.tar.xz
+tar xf arduino-1.8.2-linux64.tar.xz
+mv arduino-1.8.2 $HOME/arduino_ide
 wget https://raw.githubusercontent.com/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
 chmod +x $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder

--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,13 @@ sleep 3
 export DISPLAY=:1.0
 
 # download and install arduino 1.8.0
-wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
-tar xf arduino-1.8.0-linux64.tar.xz
-mv arduino-1.8.0 $HOME/arduino_ide
+#wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
+#tar xf arduino-1.8.0-linux64.tar.xz
+#mv arduino-1.8.0 $HOME/arduino_ide
+# Test hourly
+wget https://downloads.arduino.cc/arduino-nightly-linux64.tar.xz
+tar xf arduino-nightly-linux64.tar.xz
+mv arduino-nightly $HOME/arduino_ide
 
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # associative array for the platforms that will be verified in build_main_platforms()
 # this will be eval'd in the functions below because arrays can't be exported
-export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:zero" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" circuitplay32u4="arduino:avr:circuitplay32u4" )'
+export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:zero" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4]="arduino:avr:circuitplay32u4" )'
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ export DISPLAY=:1.0
 wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
 tar xf arduino-1.8.0-linux64.tar.xz
 mv arduino-1.8.0 $HOME/arduino_ide
-cat < EOF > $HOME/arduino_ide/arduino-headless.sh
+cat << EOF > $HOME/arduino_ide/arduino-headless.sh
 #!/bin/bash
 killall -9 Xvfb
 sleep 3s

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ export DISPLAY=:1.0
 wget https://downloads.arduino.cc/arduino-1.8.1-linux64.tar.xz
 tar xf arduino-1.8.1-linux64.tar.xz
 mv arduino-1.8.1 $HOME/arduino_ide
-wget https://raw.githubusercontent.com/fede2cr/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
+wget https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
 chmod +x $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # associative array for the platforms that will be verified in build_main_platforms()
 # this will be eval'd in the functions below because arrays can't be exported
-export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:arduino_zero_native" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
+export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:arduino_zero_native" [esp8266]="esp8266:esp8266:generic" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ tar xf arduino-1.8.0-linux64.tar.xz
 mv arduino-1.8.0 $HOME/arduino_ide
 wget https://raw.githubusercontent.com/fede2cr/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
 chmod +x $HOME/arduino_ide/arduino-headless.sh
+ls -l $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # associative array for the platforms that will be verified in build_main_platforms()
 # this will be eval'd in the functions below because arrays can't be exported
-export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:arduino_zero_native" [esp8266]="esp8266:esp8266:huzzah:UploadTool=esptool" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
+export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:arduino_zero_native" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,7 @@ wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
 tar xf arduino-1.8.0-linux64.tar.xz
 mv arduino-1.8.0 $HOME/arduino_ide
 wget https://raw.githubusercontent.com/fede2cr/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
+chmod +x $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library
 

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,6 @@ tar xf arduino-1.8.0-linux64.tar.xz
 mv arduino-1.8.0 $HOME/arduino_ide
 wget https://raw.githubusercontent.com/fede2cr/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
 chmod +x $HOME/arduino_ide/arduino-headless.sh
-ls -l $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library
 

--- a/install.sh
+++ b/install.sh
@@ -20,13 +20,9 @@ sleep 3
 export DISPLAY=:1.0
 
 # download and install arduino 1.8.0
-#wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
-#tar xf arduino-1.8.0-linux64.tar.xz
-#mv arduino-1.8.0 $HOME/arduino_ide
-# Test hourly
-wget https://downloads.arduino.cc/arduino-nightly-linux64.tar.xz
-tar xf arduino-nightly-linux64.tar.xz
-mv arduino-nightly $HOME/arduino_ide
+wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
+tar xf arduino-1.8.0-linux64.tar.xz
+mv arduino-1.8.0 $HOME/arduino_ide
 
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # associative array for the platforms that will be verified in build_main_platforms()
 # this will be eval'd in the functions below because arrays can't be exported
-export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:arduino_zero_native" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
+export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:arduino_zero_native" [esp8266]="esp8266:esp8266:huzzah:UploadTool=esptool" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported

--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,9 @@ sleep 3
 export DISPLAY=:1.0
 
 # download and install arduino 1.6.5
-wget https://downloads.arduino.cc/arduino-1.6.5-linux64.tar.xz
-tar xf arduino-1.6.5-linux64.tar.xz
-mv arduino-1.6.5 $HOME/arduino_ide
+wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
+tar xf arduino-1.8.0-linux64.tar.xz
+mv arduino-1.8.0 $HOME/arduino_ide
 
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # associative array for the platforms that will be verified in build_main_platforms()
 # this will be eval'd in the functions below because arrays can't be exported
-export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:zero" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4]="arduino:avr:circuitplay32u4" )'
+export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:zero" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported
@@ -19,7 +19,7 @@ export AUX_PLATFORMS='declare -A aux_platforms=( [trinket]="adafruit:avr:trinket
 sleep 3
 export DISPLAY=:1.0
 
-# download and install arduino 1.6.5
+# download and install arduino 1.8.0
 wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
 tar xf arduino-1.8.0-linux64.tar.xz
 mv arduino-1.8.0 $HOME/arduino_ide

--- a/install.sh
+++ b/install.sh
@@ -23,17 +23,7 @@ export DISPLAY=:1.0
 wget https://downloads.arduino.cc/arduino-1.8.0-linux64.tar.xz
 tar xf arduino-1.8.0-linux64.tar.xz
 mv arduino-1.8.0 $HOME/arduino_ide
-cat << EOF > $HOME/arduino_ide/arduino-headless.sh
-#!/bin/bash
-killall -9 Xvfb
-sleep 3s
-Xvfb :1 -nolisten tcp -screen :1 1280x800x24 &
-xvfb="$!"
-sleep 3s
-DISPLAY=:1 arduino "$@"
-kill -9 $xvfb
-EOF
-chmod a+x $HOME/arduino_id/arduino-headless.sh
+wget https://raw.githubusercontent.com/fede2cr/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # associative array for the platforms that will be verified in build_main_platforms()
 # this will be eval'd in the functions below because arrays can't be exported
-export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:zero" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
+export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:arduino_zero_native" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" [circuitplay32u4cat]="arduino:avr:circuitplay32u4cat" )'
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ export DISPLAY=:1.0
 wget https://downloads.arduino.cc/arduino-1.8.1-linux64.tar.xz
 tar xf arduino-1.8.1-linux64.tar.xz
 mv arduino-1.8.1 $HOME/arduino_ide
-wget https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
+wget https://raw.githubusercontent.com/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/master/arduino-headless.sh -O $HOME/arduino_ide/arduino-headless.sh
 chmod +x $HOME/arduino_ide/arduino-headless.sh
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Adafruit_Test_Library

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # associative array for the platforms that will be verified in build_main_platforms()
 # this will be eval'd in the functions below because arrays can't be exported
-export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:zero" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" )'
+export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]="arduino:sam:arduino_due_x" [zero]="arduino:samd:zero" [esp8266]="esp8266:esp8266:huzzah" [leonardo]="arduino:avr:leonardo" circuitplay32u4="arduino:avr:circuitplay32u4" )'
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported


### PR DESCRIPTION
This change does 4 things:
- Add support for Circuit Playground (32u4 version)
- Upgrades to Arduino IDE 1.8.1
- Creates an "arduino-headless" script to make it easy to run travis tests with this code.
- "Zero" boards are now called "zero-native".

Limitations:
- None at the moment. With 1.8.0 the ESP8266 didn't work, not it does.

Tests:
- Is passing the travis tests for all of the boards.

PS. Hi form Costa Rica :)