### PR TITLE
Fix building PRs on adafruit/travis-ci-arduino 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
      - ARDUINO_IDE_VERSION="1.8.5"
 before_install:
-  - bash $TRAVIS_BUILD_DIR/install.sh
+  - source $TRAVIS_BUILD_DIR/install.sh
 script:
   - build_platform esp32
   - build_platform uno

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
      - ARDUINO_IDE_VERSION="1.8.5"
 before_install:
-  - source <(curl -SLs https://raw.githubusercontent.com/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/install.sh)
+  - bash $TRAVIS_BUILD_DIR/install.sh
 script:
   - build_platform esp32
   - build_platform uno


### PR DESCRIPTION
This should do the trick, currently is used install.sh from base, not from merged repo. As it now uses local script it should be also faster.