### PR TITLE
Bump Arduino IDE version to 1.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git:
   quiet: true
 env:
   global:
-     - ARDUINO_IDE_VERSION="1.8.5"
+     - ARDUINO_IDE_VERSION="1.8.7"
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
 install:

--- a/example_travis.yml
+++ b/example_travis.yml
@@ -9,7 +9,7 @@ git:
   quiet: true
 env:
   global:
-     - ARDUINO_IDE_VERSION="1.8.5"
+     - ARDUINO_IDE_VERSION="1.8.7"
      - PRETTYNAME="Adafruit FT6206 Arduino Library"
 # Optional, will default to "$TRAVIS_BUILD_DIR/Doxyfile"
 #    - DOXYFILE: $TRAVIS_BUILD_DIR/Doxyfile


### PR DESCRIPTION
Updated the Arduino IDE versions in the example Travis configurations.

More specifically, the exmple configurations found in README.md and example_travis.yml
