### PR TITLE
Add space in external libraries bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ $ travis_skip esp8266
 ## Using external libraries
 External libraries (which are not hosted by the Arduino library manager) can be installed using the following command:
 ```
-- if [! -d "$HOME/arduino_ide/libraries/<Name>" ]; then git clone <URL> $HOME/arduino_ide/libraries/<Name>; fi
+- if [ ! -d "$HOME/arduino_ide/libraries/<Name>" ]; then git clone <URL> $HOME/arduino_ide/libraries/<Name>; fi
 ```


### PR DESCRIPTION
A simple README change to fix a ` [!: command not found` error when using the external library download script.