### PR TITLE
Preserve temporary files after compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,26 @@ External libraries (which are not hosted by the Arduino library manager) can be 
 ```
 - if [ ! -d "$HOME/arduino_ide/libraries/<Name>" ]; then git clone <URL> $HOME/arduino_ide/libraries/<Name>; fi
 ```
+
+## Deploying compiled artifacts
+If you need to get hold of the compiled sketches of your project, in order to release them or forward them to an
+deployment pipeline, you can find them in the `$ARDUINO_HEX_DIR` directory. Specifically, if `Foo` is the name
+of your project, you are compiling for an `Arduino Mega` and the primary sketch is called `Foo.ino`, the flashable
+`.hex` files will be found inside `$ARDUINO_HEX_DIR/mega2560/Foo` as `Foo.ino.hex` and `Foo.ino.with_bootloader.hex`.
+Similarly for the rest of the platforms.
+
+For example, assuming you have a `Foo` project as outlined above, to create a release which includes the `.hex`
+files on GitHub, you could add this to your `.travis.yml` configuration:
+
+```yaml
+deploy:
+  provider: releases
+  api_key:
+    secure: YOUR_API_KEY_ENCRYPTED
+  file:
+    - $ARDUINO_HEX_DIR/mega2560/Foo/Foo.ino.hex
+    - $ARDUINO_HEX_DIR/mega2560/Foo/Foo.ino.with_bootloader.hex
+  skip_cleanup: true
+  on:
+    tags: true
+```

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,9 @@ echo -n "CACHED: "
 echo -e """$GREEN""\xe2\x9c\x93"
 fi
 
+# define output directory for .hex files
+export ARDUINO_HEX_DIR=$HOME/compiled_arduino_sketches/arduino_build_$TRAVIS_BUILD_NUMBER
+
 # link test library folder to the arduino libraries folder
 ln -s $TRAVIS_BUILD_DIR $HOME/arduino_ide/libraries/Adafruit_Test_Library
 
@@ -345,11 +348,15 @@ function build_platform()
 
     fi
 
+    # get the sketch name so we can place the generated files in the respective folder
+    local sketch_filename_with_ending=$(basename -- "$example")
+    local sketch_filename="${sketch_filename_with_ending%.*}"
+    local build_path=$ARDUINO_HEX_DIR/$platform_key/$sketch_filename
     # verify the example, and save stdout & stderr to a variable
     # we have to avoid reading the exit code of local:
     # "when declaring a local variable in a function, the local acts as a command in its own right"
     local build_stdout
-    build_stdout=$(arduino --verify $example 2>&1)
+    build_stdout=$(arduino --verify --pref build.path=$build_path --preserve-temp-files $example 2>&1)
 
     # echo output if the build failed
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Preserve the temporary files (e.g. '.hex') so they can be found
at a deterministic location and be deployed if there's a need to.
This can be particularly useful in cases where the user needs
to release the compiled binaries or push them to a deployment
pipeline.
The patch introduces a new variable, i.e. `$ARDUINO_HEX_DIR`,
that exposes in a deterministic manner the directory in which
the temporary files are located. Further details on how to use
this variable can be found in the updated `README.md`.