### PR TITLE
Bump Arduino IDE version to 1.8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git:
 env:
   global:
      # You can uncomment this to explicitly choose an (old) version of the Arduino IDE
-     #- ARDUINO_IDE_VERSION="1.8.7"
+     #- ARDUINO_IDE_VERSION="1.8.10"
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
 install:

--- a/example_travis.yml
+++ b/example_travis.yml
@@ -16,7 +16,7 @@ addons:
       - clang-format-5.0
 env:
   global:
-#    - ARDUINO_IDE_VERSION="1.8.7"
+#    - ARDUINO_IDE_VERSION="1.8.10"
      - PRETTYNAME="Adafruit FT6206 Arduino Library"
 # Optional, will default to "$TRAVIS_BUILD_DIR/Doxyfile"
 #    - DOXYFILE: $TRAVIS_BUILD_DIR/Doxyfile

--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,7 @@ echo "########################################################################";
 
 # if .travis.yml does not set version
 if [ -z $ARDUINO_IDE_VERSION ]; then
-export ARDUINO_IDE_VERSION="1.8.9"
+export ARDUINO_IDE_VERSION="1.8.10"
 echo "NOTE: YOUR .TRAVIS.YML DOES NOT SPECIFY ARDUINO IDE VERSION, USING $ARDUINO_IDE_VERSION"
 fi
 


### PR DESCRIPTION
Updated the Arduino IDE version to 1.8.10.

This also aligns the Arduino IDE version used in the README, example Travis configuration and install script. Previously they were either referring to version 1.8.7 or 1.8.9.

Full release notes for the Arduino IDE 1.8.10 are found [here](https://www.arduino.cc/en/Main/ReleaseNotes).